### PR TITLE
Feature: Squash log sequence & Discard no-change updates

### DIFF
--- a/loggings/constants.py
+++ b/loggings/constants.py
@@ -1,3 +1,10 @@
 ACTION_CREATE = 1
 ACTION_UPDATE = 2
 ACTION_DELETE = 3
+
+ACTION_TO_STRING = {
+    1: "create",
+    2: "update",
+    3: "delete"
+}
+

--- a/loggings/constants.py
+++ b/loggings/constants.py
@@ -3,8 +3,7 @@ ACTION_UPDATE = 2
 ACTION_DELETE = 3
 
 ACTION_TO_STRING = {
-    1: "create",
-    2: "update",
-    3: "delete"
+    ACTION_CREATE: "create",
+    ACTION_UPDATE: "update",
+    ACTION_DELETE: "delete"
 }
-

--- a/loggings/helpers.py
+++ b/loggings/helpers.py
@@ -1,0 +1,37 @@
+from .models import LogExtra
+
+
+def normalize_extras(obj, extras=None, manual_extras=None):
+    """
+    obj - the instance to lookup attributes on
+    extras - a list of attributes, using __ for chaining
+    manual_extras - a list of tuples (field, val)
+    """
+    resolved_extras = []
+
+    # Resolve attribute names into tuple(key, val)
+    for extra in set(extras or []):
+        val = obj
+        for field_name in extra.split("__"):
+            val = getattr(val, field_name)
+        resolved_extras.append((field_name, val))
+
+    # Treat extras/manual extras the same
+    combined_extras = resolved_extras + (manual_extras or [])
+    unique_extras = {}
+
+    # Prevent dupe key/val sets
+    for key, val in combined_extras:
+        unique_extras[f"{key} {val}"] = (key, val)
+
+    return tuple(unique_extras.values())
+
+
+def create_extra(log_id, field_name, value):
+    # Avoid duplicate extras
+    log, _ = LogExtra.objects.get_or_create(
+        log_id=log_id,
+        field_name=field_name,
+        field_value=value
+    )
+    return log

--- a/loggings/helpers.py
+++ b/loggings/helpers.py
@@ -1,3 +1,7 @@
+import json
+
+from django.core import serializers
+
 from .models import LogExtra
 
 
@@ -35,3 +39,11 @@ def create_extra(log_id, field_name, value):
         field_value=value
     )
     return log
+
+
+def serialize_obj(obj, **kwargs):
+    """Convert model instance to JSON"""
+    # serialize() requires a iterable
+    js_obj = serializers.serialize("json", [obj], **kwargs)
+    dict_obj = json.loads(js_obj)[0]
+    return json.dumps(dict_obj)

--- a/loggings/logger.py
+++ b/loggings/logger.py
@@ -1,8 +1,26 @@
+from collections import defaultdict
+import contextvars
+import json
+
 from django.core import serializers
 from django.db.models import Model
 
 from .constants import ACTION_CREATE, ACTION_DELETE, ACTION_UPDATE
 from .models import Log, LogExtra
+
+
+# Stored log id's per model instance, for use with squashing a log sequence
+log_history = contextvars.ContextVar("loggings__log_history")
+
+
+def begin_log_sequence():
+    """Begin recording log id's per model instance."""
+    return log_history.set(defaultdict(list))
+
+
+def end_log_sequence(token):
+    """End recording log id's per model instance."""
+    log_history.reset(token)
 
 
 class Logger(object):
@@ -33,15 +51,11 @@ class Logger(object):
                 raise TypeError(
                     "previous_obj must be a Django model instance.")
 
-            if (previous_obj._meta.app_label !=
-                    self.current_obj._meta.app_label):
-
+            if previous_obj._meta.app_label != self.current_obj._meta.app_label:
                 raise Exception("current_obj and previous_obj must be from "
                                 "the same Django app.")
 
-            if (previous_obj._meta.object_name !=
-                    self.current_obj._meta.object_name):
-
+            if previous_obj._meta.object_name != self.current_obj._meta.object_name:
                 raise Exception("current_obj and previous_obj must be "
                                 "instances of the same Django model.")
 
@@ -99,28 +113,102 @@ class Logger(object):
             )
 
     def create(self):
+        model = type(self.current_obj)
+        # Limit logging to editable fields
+        fields = [f.name for f in model._meta.get_fields() if f.editable]
+
         log = Log(
             action=self.action,
             app_name=self.current_obj._meta.app_label,
             model_name=self.current_obj._meta.object_name,
             model_instance_pk=self.current_obj.pk,
-            current_json_blob=serializers.serialize(
-                "json", [self.current_obj])
+            current_json_blob=serializers.serialize("json", [self.current_obj],
+                                                    fields=fields)
         )
 
         if self.previous_obj:
             log.previous_json_blob = serializers.serialize(
-                "json", [self.previous_obj])
+                "json", [self.previous_obj], fields=fields)
 
         if self.user:
             log.user_id = self.user.pk
 
-        log.save()
+        # No changes - discard this log attempt
+        if self.previous_obj and log.previous_json_blob == log.current_json_blob:
+            return None
 
-        if self.extras:
-            self._create_extra_logs(log)
+        # Unique identifier for a model instance
+        log_key = "{0.app_name}-{0.model_name}-{0.model_instance_pk}".format(log)
+        try:
+            log_history_storage = log_history.get()
+        except LookupError:
+            # No log sequence context was started - do not squash logs
+            log_history_storage = None
+            squashed_log = None
+        else:
+            # A log history sequence exists - squash them if possible
+            squashed_log, updated_log_ids = self.squash_log_sequence(
+                log, log_history_storage.get(log_key, []))
+            log_history_storage[log_key] = updated_log_ids
 
-        return log
+        if squashed_log:
+            # Store the new log sequence
+            log_history.set(log_history_storage)
+            return squashed_log
+        else:
+            log.save()
+            if log_history_storage is not None:
+                log_history_storage[log_key].append(log.id)
+                # Store the new log sequence
+                log_history.set(log_history_storage)
+
+            if self.extras:
+                self._create_extra_logs(log)
+            return log
+
+    @classmethod
+    def squash_log_sequence(cls, log, prev_log_ids):
+        """Given a non-persistant log & the ids of existing logs in the sequence, squash sequential
+           logs into a resultant log.  Returns the updated log, and the updated list of log id's"""
+        squashed_log = None
+        updated_log_ids = prev_log_ids
+
+        # Get previous logs of the same model instance
+        if prev_logs := Log.objects.filter(id__in=prev_log_ids).order_by("-timestamp"):
+            # A DELETE nullifies previous logs in the sequence - remove them.
+            if log.action == ACTION_DELETE:
+                prev_logs.delete()
+                updated_log_ids = []
+
+            # An UPDATE log can squash its changes onto previous update logs to the same
+            # object. For example - a CREATE, followed by 3 UPDATES, would squash down to a single
+            # CREATE.
+            elif log.action == ACTION_UPDATE:
+                current_log = log
+                # Logs to delete after combining
+                to_delete = []
+                for prev_log in prev_logs:
+                    # Sanity check
+                    if prev_log.action == ACTION_DELETE or current_log.action == ACTION_CREATE:
+                        # This should be impossible
+                        raise AssertionError(f"Previous log {prev_log.id}: {prev_log.action}, "
+                                             f"Current log {current_log.id} {current_log.action}")
+                    curr_log_dict = json.loads(current_log.current_json_blob)
+                    prev_log_dict = json.loads(prev_log.current_json_blob)
+                    # Update prev log with this log's changes
+                    prev_log_dict[0]["fields"].update(curr_log_dict[0]["fields"])
+                    if current_log.id:
+                        to_delete.append(current_log.id)
+                    current_log = prev_log
+                current_log.save()
+                squashed_log = current_log
+                # Delete redundant logs
+                if to_delete:
+                    prev_logs.filter(pk__in=to_delete).delete()
+                updated_log_ids = [pk for pk in prev_log_ids if pk not in to_delete]
+
+        return squashed_log, updated_log_ids
+
 
     @classmethod
     def create_manual_extra(cls, log_id, field_name, field_value):

--- a/loggings/logger.py
+++ b/loggings/logger.py
@@ -30,7 +30,7 @@ class Logger(object):
     user = None
 
     def __init__(self, action, current_obj, previous_obj=None, user=None,
-                 extras=None):
+                 extras=None, manual_extras=None):
 
         try:
             action = int(action)
@@ -92,6 +92,7 @@ class Logger(object):
                             "current instance.".format(extra))
 
             self.extras = extras
+        self.manual_extras = manual_extras
 
     def _create_extra_logs(self, log):
         for field in (self.extras or []):
@@ -112,6 +113,10 @@ class Logger(object):
                 field_name=field_name,
                 field_value=getattr(obj, field_name)
             )
+
+    def _create_manual_extras(self, log_id):
+        for field, val in (self.manual_extras or {}).items():
+            Logger.create_manual_extra(log_id, field, val)
 
     def create(self):
         model = type(self.current_obj)
@@ -245,8 +250,6 @@ class Logger(object):
         * field_value = The value, usually a primary key of the object you
                         wish to reference.
         """
-        log = Log.objects.get(pk=log_id)
-
-        extra = LogExtra.objects.create(
-            log_id=log.pk, field_name=field_name, field_value=field_value)
+        extra, _ = LogExtra.objects.get_or_create(
+            log_id=log_id, field_name=field_name, field_value=field_value)
         return extra

--- a/loggings/logger.py
+++ b/loggings/logger.py
@@ -229,8 +229,7 @@ class Logger(object):
 
         # Delete redundant logs
         if to_delete:
-            res = Log.objects.filter(pk__in=to_delete).delete()
-            print("Deleted logs", res)
+            Log.objects.filter(pk__in=to_delete).delete()
             updated_log_ids = [pk for pk in prev_log_ids if pk not in to_delete]
         return resultant_log, updated_log_ids
 

--- a/loggings/mixins.py
+++ b/loggings/mixins.py
@@ -45,7 +45,7 @@ class LogUpdateObjectMixin(LogModelObject):
         Call super to save changes to the object.
         Log the old and current objects.
         """
-        old_object = self.model.objects.get(pk=self.object.pk)
+        old_object = type(self.object).objects.get(pk=self.object.pk)
 
         response = super(LogUpdateObjectMixin, self).form_valid(form)
 

--- a/loggings/models.py
+++ b/loggings/models.py
@@ -13,19 +13,19 @@ class Log(models.Model):
     app_name = models.CharField(
         blank=True,
         db_index=True,
-        default='',
+        default="",
         max_length=255
     )
     model_name = models.CharField(
         blank=True,
         db_index=True,
-        default='',
+        default="",
         max_length=255
     )
     model_instance_pk = models.CharField(
         blank=True,
         db_index=True,
-        default='',
+        default="",
         max_length=255
     )
     timestamp = models.DateTimeField(auto_now_add=True, db_index=True)

--- a/loggings/models.py
+++ b/loggings/models.py
@@ -1,13 +1,10 @@
-try:
-    import json
-except ImportError:
-    from django.utils import simplejson as json
+import json
 
 from django.apps import apps
 from django.db import models
 from django.contrib.auth.models import User
 
-from .constants import ACTION_TO_STRING
+from .constants import ACTION_CREATE, ACTION_DELETE, ACTION_UPDATE, ACTION_TO_STRING
 
 
 class Log(models.Model):
@@ -47,6 +44,18 @@ class Log(models.Model):
             self.timestamp)
             if p
         ])
+
+    @property
+    def is_create(self):
+        return self.action == ACTION_CREATE
+
+    @property
+    def is_update(self):
+        return self.action == ACTION_UPDATE
+
+    @property
+    def is_delete(self):
+        return self.action == ACTION_DELETE
 
     @property
     def django_user(self):
@@ -116,11 +125,6 @@ class Log(models.Model):
     @property
     def action_name(self):
         return ACTION_TO_STRING[self.action]
-
-    def create_manual_extra(self, field_name, field_value):
-        extra, _ = LogExtra.objects.get_or_create(
-            log_id=self.id, field_name=field_name, field_value=field_value)
-        return extra
 
 
 class LogExtra(models.Model):

--- a/loggings/models.py
+++ b/loggings/models.py
@@ -117,6 +117,11 @@ class Log(models.Model):
     def action_name(self):
         return ACTION_TO_STRING[self.action]
 
+    def create_manual_extra(self, field_name, field_value):
+        extra, _ = LogExtra.objects.get_or_create(
+            log_id=self.id, field_name=field_name, field_value=field_value)
+        return extra
+
 
 class LogExtra(models.Model):
     """

--- a/loggings/models.py
+++ b/loggings/models.py
@@ -3,8 +3,11 @@ try:
 except ImportError:
     from django.utils import simplejson as json
 
+from django.apps import apps
 from django.db import models
 from django.contrib.auth.models import User
+
+from .constants import ACTION_TO_STRING
 
 
 class Log(models.Model):
@@ -29,23 +32,21 @@ class Log(models.Model):
         max_length=255
     )
     timestamp = models.DateTimeField(auto_now_add=True, db_index=True)
-    previous_json_blob = models.TextField(blank=True, default='')
-    current_json_blob = models.TextField(blank=True, default='')
+    previous_json_blob = models.TextField(blank=True, default="")
+    current_json_blob = models.TextField(blank=True, default="")
     user_id = models.IntegerField(blank=True, null=True)
 
     class Meta:
         ordering = ["-timestamp"]
 
-    def __unicode__(self):
-        rep = ''
-
-        if self.app_name:
-            rep = u"%s | " % self.app_name
-
-        if self.model_name:
-            rep = u"%s%s | " % (rep, self.model_name)
-
-        return u"%s%s" % (rep, self.timestamp)
+    def __str__(self):
+        return " | ".join([str(p) for p in (
+            self.action_name,
+            self.app_name,
+            self.model_name,
+            self.timestamp)
+            if p
+        ])
 
     @property
     def django_user(self):
@@ -67,6 +68,55 @@ class Log(models.Model):
             return json.dumps(self.previous_json_blob)
         return None
 
+    @property
+    def current_obj_dict(self):
+        obj_dict = json.loads(self.current_json_blob)
+        # Log json has been surrounded by a [], for some reason
+        if isinstance(obj_dict, list) and len(obj_dict):
+            obj_dict = obj_dict[0]
+        return obj_dict
+
+    @property
+    def previous_obj_dict(self):
+        if not self.previous_json_blob:
+            return None
+
+        obj_dict = json.loads(self.previous_json_blob)
+        # Log json has been surrounded by a [], for some reason
+        if isinstance(obj_dict, list) and len(obj_dict):
+            obj_dict = obj_dict[0]
+        return obj_dict
+
+    @property
+    def current_obj_fields(self):
+        """ Returns a dict of fields """
+        return self.current_obj_dict["fields"]
+
+    @property
+    def previous_obj_fields(self):
+        """ Returns a dict of fields """
+        return self.previous_obj_dict["fields"]
+
+    def get_model(self):
+        """ Return the log subject's model """
+        try:
+            return apps.get_model(app_label=self.app_name, model_name=self.model_name)
+        except LookupError:
+            return None
+
+    def get_model_instance(self):
+        """ Returns the log subject's model instance """
+        if model := self.get_model():
+            try:
+                return model.objects.get(pk=self.model_instance_pk)
+            except model.DoesNotExist:
+                pass
+        return None
+
+    @property
+    def action_name(self):
+        return ACTION_TO_STRING[self.action]
+
 
 class LogExtra(models.Model):
     """
@@ -84,5 +134,5 @@ class LogExtra(models.Model):
     class Meta:
         ordering = ["-log__timestamp"]
 
-    def __unicode__(self):
-        return self.log.__unicode__()
+    def __str__(self):
+        return self.log.__str__()


### PR DESCRIPTION
Adds the ability to start recording a "log sequence", and squash the logs in that sequence into a shorter sequence.
For example, a CREATE & 2 UPDATES will flatten to a CREATE, or 2 UPDATES and a DELETE will flatten to a DELETE.  

Non-editable fields are discarded from the JSON representation, which cleans up auto-generated timestamps and other items that the user did not explicitely change. 

UPDATE logs that have no diff will be discarded before they are created.  We have plenty of log entries where nothing changed.

